### PR TITLE
enable computation on CUDA device

### DIFF
--- a/torch_pesq/bark.py
+++ b/torch_pesq/bark.py
@@ -128,10 +128,11 @@ class BarkScale(torch.nn.Module):
         Filterbank matrix converting power spectrum to band powers
     device : torch.device
         The location to allocate for PyTorch tensors. (Default: cpu)
-
     """
 
-    def __init__(self, nfreqs: int = 256, nbarks: int = 49, device: torch.device = 'cpu'):
+    def __init__(
+        self, nfreqs: int = 256, nbarks: int = 49, device: torch.device = "cpu"
+    ):
         super(BarkScale, self).__init__()
 
         self.pow_dens_correction = Parameter(

--- a/torch_pesq/loss.py
+++ b/torch_pesq/loss.py
@@ -68,7 +68,7 @@ class PesqLoss(torch.nn.Module):
         win_length: int = 512,
         n_fft: int = 512,
         hop_length: int = 256,
-        device: torch.device = 'cpu'
+        device: torch.device = "cpu",
     ):
         super(PesqLoss, self).__init__()
 
@@ -98,14 +98,16 @@ class PesqLoss(torch.nn.Module):
         # design IIR bandpass filter for power degation between 325Hz to 3.25kHz
         out = np.asarray(butter(5, [325, 3250], fs=16000, btype="band"))
         self.power_filter = Parameter(
-            torch.as_tensor(out, dtype=torch.float32, device=device), requires_grad=False
+            torch.as_tensor(out, dtype=torch.float32, device=device),
+            requires_grad=False,
         )
 
         # use IIR filter for pre-emphasize
         self.pre_filter = Parameter(
             torch.tensor(
                 [[2.740826, -5.4816519, 2.740826], [1.0, -1.9444777, 0.94597794]],
-                dtype=torch.float32, device=device
+                dtype=torch.float32,
+                device=device,
             ),
             requires_grad=False,
         )

--- a/torch_pesq/loudness.py
+++ b/torch_pesq/loudness.py
@@ -32,6 +32,8 @@ class Loudness(torch.nn.Module):
     ----------
     nbark : int
         Number of bark bands
+    device : torch.device
+        The location to allocate for PyTorch tensors. (Default: cpu)
 
     Attributes
     ----------
@@ -41,15 +43,15 @@ class Loudness(torch.nn.Module):
         Exponent of each band
     """
 
-    def __init__(self, nbark: int = 49):
+    def __init__(self, nbark: int = 49, device: torch.device = 'cpu'):
         super(Loudness, self).__init__()
 
         self.threshs = Parameter(
             interp(abs_thresh_power_16k, nbark).unsqueeze(0).unsqueeze(0),
             requires_grad=False,
-        )
+        ).to(device)
 
-        exp = 6 / (torch.tensor(centre_of_band_bark_16k) + 2.0)
+        exp = 6 / (torch.tensor(centre_of_band_bark_16k, device=device) + 2.0)
         self.exp = Parameter(
             exp.clamp(min=1.0, max=2.0) ** 0.15 * zwicker_power, requires_grad=False
         )

--- a/torch_pesq/loudness.py
+++ b/torch_pesq/loudness.py
@@ -43,7 +43,7 @@ class Loudness(torch.nn.Module):
         Exponent of each band
     """
 
-    def __init__(self, nbark: int = 49, device: torch.device = 'cpu'):
+    def __init__(self, nbark: int = 49, device: torch.device = "cpu"):
         super(Loudness, self).__init__()
 
         self.threshs = Parameter(


### PR DESCRIPTION
Currently, `PesqLoss` can only be computed on CPU. I added the required device arguments to enable computation on GPU.

Attention: The changes of this PR require `torchaudio.transforms.Resample` to have a device keyword, which is currently not the case. I also submitted a PR to torchaudio (https://github.com/pytorch/audio/pull/3247). We should only consider merging here after the PR in torchaudio is merged.